### PR TITLE
Fix: Correct typos in Manual Scene (View) Tracking section of Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ logger.Debug("Hello with attributes", new()
 
 ### Manual Scene (View) Tracking
 
-To manually track new Scenes (`Views` id Datadog), use the `StartVeiw` and `StopView` methods:
+To manually track new Scenes (`Views` in Datadog), use the `StartView` and `StopView` methods:
 
 ```cs
 public void Start()


### PR DESCRIPTION
- Fixed typo: "`Views` id Datadog" -> "`Views` in Datadog"
- Fixed typo: "Use the `StartVeiw`" -> "Use the `StartView`"